### PR TITLE
Feature/fix for issue 111 try 2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
         // scheme for these version numbers: EPOCH MAJOR MINOR PATCH BUILD
-        versionCode 1_04_00_00_11
+        versionCode 1_04_00_00_12
         versionName  "4.0.0"
 
         vectorDrawables.useSupportLibrary = false  // no need for this since we're min SDK=21

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/apconnector/ApConnectorApi21.kt
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/apconnector/ApConnectorApi21.kt
@@ -6,7 +6,6 @@ import android.content.IntentFilter
 import android.net.wifi.WifiConfiguration
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
-import android.os.Build.VERSION
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.MainThread
@@ -53,8 +52,6 @@ class ApConnectorApi21(
         wifiStateChangeListener = SimpleReceiver.newRegisteredReceiver(
             appContext, WIFI_STATE_CHANGE_FILTER
         ) { ctx: Context?, intent: Intent -> onWifiChangeBroadcastReceived(intent, config) }
-        val useMoreComplexConnectionProcess = VERSION.SDK_INT < 18
-
 
         // we don't need this for its atomicity, we just need it as a 'final' reference to an
         // integer which can be shared by a couple of the Runnables below
@@ -64,7 +61,7 @@ class ApConnectorApi21(
         // wonkiness I ran into when trying to do every one of these steps one right after
         // the other on the same thread.
         val alreadyConfiguredId = wifiFacade.getIdForConfiguredNetwork(configSSID)
-        if (alreadyConfiguredId != -1 && !useMoreComplexConnectionProcess) {
+        if (alreadyConfiguredId != -1) {
             // For some unexplained (and probably sad-trombone-y) reason, if the AP specified was
             // already configured and had been connected to in the past, it will often get to
             // the "CONNECTING" event, but just before firing the "CONNECTED" event, the
@@ -82,7 +79,7 @@ class ApConnectorApi21(
                 }
             }
         }
-        if (alreadyConfiguredId == -1 || !useMoreComplexConnectionProcess) {
+        if (alreadyConfiguredId == -1) {
             setupRunnables.add {
                 log.d("Adding network $configSSID")
                 networkID.set(wifiFacade.addNetwork(config))
@@ -100,21 +97,9 @@ class ApConnectorApi21(
                 }
             }
         }
-        if (useMoreComplexConnectionProcess) {
-            setupRunnables.add {
-                log.d("Disconnecting from networks; reconnecting momentarily.")
-                wifiFacade.disconnect()
-            }
-        }
         setupRunnables.add {
             log.i("Enabling network " + configSSID + " with network ID " + networkID.get())
-            wifiFacade.enableNetwork(networkID.get(), !useMoreComplexConnectionProcess)
-        }
-        if (useMoreComplexConnectionProcess) {
-            setupRunnables.add {
-                log.d("Disconnecting from networks; reconnecting momentarily.")
-                wifiFacade.reconnect()
-            }
+            wifiFacade.enableNetwork(networkID.get(), true)
         }
         val currentlyConnectedSSID = wifiFacade.currentlyConnectedSSID
         softAPConfigRemover.onWifiNetworkDisabled(currentlyConnectedSSID)

--- a/devicesetup/src/main/java/io/particle/android/sdk/utils/WifiFacade.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/utils/WifiFacade.java
@@ -133,6 +133,29 @@ public class WifiFacade {
                     if (capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_WIFI_P2P)) {
                         return false;
                     }
+                    // Don't use any connections if they have internet! (workaround for issue #111)
+                    //
+                    // Due to a known issue with certain Android phones (e.g. Pixel 6/7 series)
+                    // running Android 12 or above, these devices may retain access to their current
+                    // Wi-Fi network while also connecting to a Particle Wi-Fi Module in SoftAP mode.
+                    // This is the Android 12 "Wi-Fi STA/STA concurrency" feature, which lets a
+                    // device connect to two Wi-Fi networks at once and which the user can't disable.
+                    //
+                    // The "correct" approach via the ConnectivityManager APIs (SDK 31+) proved
+                    // unreliable due to the bugs tracked at:
+                    //   https://issuetracker.google.com/issues/249023377
+                    //   https://issuetracker.google.com/issues/232107693
+                    // After exhaustive testing of that approach, the Android system source itself
+                    // was examined; it uses a similar internet-capability check to decide whether a
+                    // network is a "valid" internet connection it should not bind to.
+                    //
+                    // Excluding all internet-capable networks here forces binding to the local-only
+                    // SoftAP network (the Particle device). Not a perfect fix (future Android
+                    // changes could affect it), but reliable across Pixel phones from the latest
+                    // models back to Android 5. See the issue trackers above for more.
+                    if (capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+                        return false;
+                    }
                     return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
                 }
         );


### PR DESCRIPTION
**This is a second attempt to fix issue 111**

Issue 111 describes an issue that can occur during the setup of a Particle Photon using a subset of Android phones running Android 12 or above. 

The following SKUs are affected running any Device OS version and below:

- Photon
- P1/P0

This issue impacts all versions of the Particle Android SDK.

**Root Cause and Symptoms** 

Android 12 introduced a new Wi-Fi feature known as Wi-Fi STA/STA concurrency. This allows devices to connect to two Wi-Fi networks concurrently.
This feature is designed to support make-before-break Wi-Fi continuity (for Wi-Fi roaming situations) as well as support concurrent local-only and internet connectivity connections. In Android 13, the feature was expanded to support connections to multiple internet providing networks at the same time.
This feature is limited to Android phones that contain a Wi-Fi chip and firmware that can support two concurrent STA connections. As of this date of writing, this list of phones includes the following models:

- Google Pixel 6 / 6 Pro / 6a
- Google Pixel 7 / 7 Pro
- Google Pixel Fold

**Behavior when connected to Particle P0/P1/Photon Module**

When connecting to a Particle Wi-Fi Module using SoftAP mode for the purposes of onboarding the device to a Wi-Fi network, the impacted Android devices can retain access to the current Wi-Fi network they are attached to. 
Android Phones

This feature can’t be disable by the user.

**Note from the code:**

Due to a known issue with certain Android phones (e.g., Pixel 6/7 series) running Android 12 or above, 
these devices may retain access to their current Wi-Fi network while also connecting to a Particle Wi-Fi Module 
in SoftAP mode. This behavior is due to a feature introduced in Android 12 known as Wi-Fi STA/STA concurrency, 
which allows devices to connect to two Wi-Fi networks concurrently.

The correct way to handle this programmatically using Android's ConnectivityManager APIs (SDK 31+) has proven 
to be unreliable due to the bugs tracked at:
https://issuetracker.google.com/issues/249023377
https://issuetracker.google.com/issues/232107693

Exhaustive testing was done after implementing this the correct way and it just didn't work.
Before giving up, the Android source code was examined to see how the system itself handles this situation.
In that code, we found a similar hack to the one below, which is used to determine whether a network is
a "valid" internet connection. If it is, then the system will not bind to it.

The current workaround involves excluding all networks with internet capability when binding to a network. 
While this is not a perfect fix (as future changes in Android might affect its effectiveness), this solution 
has proven to be reliable for the time being and manages to address the issue across all Pixel phones tested, 
ranging from the latest models back to those running Android 5.

For more information, refer to the aforementioned issue trackers.