### PR TITLE
Enable OS autofill / password-manager integration on auth screens

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
         // scheme for these version numbers: EPOCH MAJOR MINOR PATCH BUILD
-        versionCode 1_04_00_00_12
+        versionCode 1_04_00_00_13
         versionName  "4.0.0"
 
         vectorDrawables.useSupportLibrary = false  // no need for this since we're min SDK=21

--- a/devicesetup/src/main/res/layout/activity_create_account.xml
+++ b/devicesetup/src/main/res/layout/activity_create_account.xml
@@ -42,6 +42,8 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="@dimen/edittext_form_element_gap"
+                android:autofillHints="personGivenName"
+                android:importantForAutofill="yes"
                 android:hint="@string/prompt_first_name"
                 android:inputType="textPersonName|textCapWords"/>
 
@@ -50,6 +52,8 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="@dimen/edittext_form_element_gap"
+                android:autofillHints="personFamilyName"
+                android:importantForAutofill="yes"
                 android:hint="@string/prompt_last_name"
                 android:inputType="textPersonName|textCapWords"/>
 
@@ -58,6 +62,8 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="@dimen/edittext_form_element_gap"
+                android:autofillHints="emailAddress"
+                android:importantForAutofill="yes"
                 android:hint="@string/prompt_email"
                 android:inputType="textEmailAddress"/>
 
@@ -66,6 +72,8 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="@dimen/edittext_form_element_gap"
+                android:autofillHints="newPassword"
+                android:importantForAutofill="yes"
                 android:hint="@string/prompt_password"
                 android:inputType="textPassword"/>
 
@@ -74,6 +82,8 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="@dimen/edittext_form_element_gap"
+                android:autofillHints="newPassword"
+                android:importantForAutofill="yes"
                 android:hint="@string/prompt_verify_password"
                 android:imeOptions="actionDone"
                 android:inputType="textPassword"/>

--- a/devicesetup/src/main/res/layout/activity_password_reset.xml
+++ b/devicesetup/src/main/res/layout/activity_password_reset.xml
@@ -39,6 +39,8 @@
             android:layout_marginLeft="12dp"
             android:layout_marginRight="12dp"
             android:layout_marginBottom="24dp"
+            android:autofillHints="emailAddress"
+            android:importantForAutofill="yes"
             android:hint="@string/prompt_email"
             android:inputType="textEmailAddress"/>
 

--- a/devicesetup/src/main/res/layout/activity_two_factor.xml
+++ b/devicesetup/src/main/res/layout/activity_two_factor.xml
@@ -54,8 +54,9 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="@dimen/edittext_form_element_gap"
+                android:autofillHints="smsOTPCode"
                 android:hint="@string/login_code_hint"
-                android:importantForAutofill="no"
+                android:importantForAutofill="yes"
                 android:inputType="number"/>
 
             <RelativeLayout

--- a/devicesetup/src/main/res/layout/particle_activity_login.xml
+++ b/devicesetup/src/main/res/layout/particle_activity_login.xml
@@ -45,6 +45,8 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="@dimen/edittext_form_element_gap"
+                android:autofillHints="emailAddress"
+                android:importantForAutofill="yes"
                 android:hint="@string/prompt_email"
                 android:inputType="textEmailAddress"/>
 
@@ -53,6 +55,8 @@
                 style="@style/SparkEditText"
                 android:layout_width="match_parent"
                 android:layout_marginBottom="4dp"
+                android:autofillHints="password"
+                android:importantForAutofill="yes"
                 android:hint="@string/prompt_password"
                 android:imeActionId="@+id/action_log_in"
                 android:imeActionLabel="@string/action_log_in_short"


### PR DESCRIPTION
## Problem

The login email/password boxes don't trigger OS password-manager / autofill integration. The auth-screen `EditText`s declared `inputType` but no `android:autofillHints`, so Android's Autofill Framework (and Google Password Manager, 1Password, etc.) didn't recognise them — no fill, no save prompt. The **2FA field was actively opted out** with `importantForAutofill="no"`.

## Fix

Added the standard autofill hints across all auth screens:

| Screen | Field(s) | Hint |
|---|---|---|
| Login | email / password | `emailAddress` / `password` |
| Create account | first / last / email / password / verify | `personGivenName` / `personFamilyName` / `emailAddress` / `newPassword` / `newPassword` |
| Password reset | email | `emailAddress` |
| Two-factor | code | `smsOTPCode` + `importantForAutofill="yes"` (was `"no"`) |

`newPassword` on signup lets managers offer to **save** the new credential; `smsOTPCode` lets the OS/keyboard fill the one-time code. All hints are no-ops below API 26, so minSdk 21 is unaffected.

versionCode → build 13.

## Test status

Builds, installs and launches on a Pixel 8 Pro (Android 15); the device has Google's autofill service active. A full live autofill test needs the logged-out login screen plus a saved particle.io credential in a password manager — couldn't exercise that here without logging out the active session, so the end-to-end fill/save prompt still wants a quick manual confirmation.